### PR TITLE
[BLUE-1799] Ensure we can set the context for authenticated websockets

### DIFF
--- a/lib/apollo_socket/absinthe_message_handler.ex
+++ b/lib/apollo_socket/absinthe_message_handler.ex
@@ -6,13 +6,14 @@ defmodule ApolloSocket.AbsintheMessageHandler do
 
   @impl ApolloSocket.MessageHandler
   def init(opts) when is_list(opts) do
-    {known_opts, _} = Keyword.split(opts, [:schema, :pubsub, :broker_sup])
+    {known_opts, _} = Keyword.split(opts, [:schema, :pubsub, :broker_sup, :context])
     Enum.into(known_opts, %{})
   end
 
   @impl ApolloSocket.MessageHandler
   def handle_start(apollo_socket, operation_id, operation_name, graphql_doc, variables, opts) do
-    absinthe_opts = [context: %{pubsub: opts[:pubsub]}]
+    context = Map.merge(opts[:context] || %{}, %{pubsub: opts[:pubsub]})
+    absinthe_opts = [context: context]
     |> add_operation_name(operation_name)
     |> add_variables(variables)
 


### PR DESCRIPTION
Exposes the context as an option so we can set it in our custom websocket transport for authenticating subscriptions.