### PR TITLE
Support stop operations in absinthe message handler

### DIFF
--- a/lib/apollo_socket/absinthe_message_handler.ex
+++ b/lib/apollo_socket/absinthe_message_handler.ex
@@ -38,6 +38,15 @@ defmodule ApolloSocket.AbsintheMessageHandler do
     end
   end
 
+  def handle_stop(apollo_socket, operation_id, opts) do
+    pubsub = apollo_socket.message_handler_opts[:pubsub]
+    callback = apollo_socket.message_handler_opts[:unsubscribe_fun]
+
+    callback.(operation_id, pubsub)
+
+    {:ok, opts}
+  end
+
   defp data_broker_child_spec(pubsub, absinthe_subscription_id, operation_id, socket) do
     %{
       type: :worker,

--- a/lib/apollo_socket/message_handler.ex
+++ b/lib/apollo_socket/message_handler.ex
@@ -5,7 +5,7 @@ defmodule ApolloSocket.MessageHandler do
 
   @type apollo_socket :: %ApolloSocket{}
   @type message_handler_opts :: any()
-  @type message_handler_result :: {:ok, message_handler_opts} | 
+  @type message_handler_result :: {:ok, message_handler_opts} |
     {:reply, %OperationMessage{}, message_handler_opts} |
     {:reply, list(%OperationMessage{}), message_handler_opts}
 
@@ -66,4 +66,4 @@ defmodule ApolloSocket.MessageHandler do
       defoverridable ApolloSocket.MessageHandler
     end
   end
-end 
+end


### PR DESCRIPTION
Adds support for socket unsubscriptions.

Original logic used the default implementation of the behaviour which did nothing, see: https://github.com/dazzlerocks/absinthe_apollo_sockets/blob/master/lib/apollo_socket/message_handler.ex#L60